### PR TITLE
Migrate from Mono.GetOptions to Mono.Options + various fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ yyyy-mm-dd  Andreas Windischer
 
 	* HtmlExporter.cs: Never used private fields removed.
 	* gui/gtk/CoverageView.cs: Never used private field removed.
+	* MonoConvMain.cs: xml/html-export error handling added.
 
 2010-12-30  Andreas Windischer
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-yyyy-mm-dd  Andreas Windischer
+2010-12-30  Andreas Windischer
 
 	* HtmlExporter.cs: Never used private fields removed.
 	* gui/gtk/CoverageView.cs: Never used private field removed.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2010-12-30  Andreas Windischer
+
+	* MonoCovMain.cs, MonoCovOptions.cs, gui/gtk/MonoCov.cs, gui/qt/MonoCov.cs, gui/gtk/MonoCov.cs, Makefile, configure:
+	Migrate from Mono.GetOptions (obsolete) to Mono.Options
+
 2010-12-28  Andreas Windischer
 
 	* gui/gtk/MonoCov.cs: catch file open error.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+yyyy-mm-dd  Andreas Windischer
+
+	* HtmlExporter.cs: Never used private fields removed.
+	* gui/gtk/CoverageView.cs: Never used private field removed.
+
 2010-12-30  Andreas Windischer
 
 	* MonoCovMain.cs, MonoCovOptions.cs, gui/gtk/MonoCov.cs, gui/qt/MonoCov.cs, gui/gtk/MonoCov.cs, Makefile, configure:

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,9 +3,6 @@
 	* HtmlExporter.cs: Never used private fields removed.
 	* gui/gtk/CoverageView.cs: Never used private field removed.
 	* MonoConvMain.cs: xml/html-export error handling added.
-
-2010-12-30  Andreas Windischer
-
 	* MonoCovMain.cs, MonoCovOptions.cs, gui/gtk/MonoCov.cs, gui/qt/MonoCov.cs, gui/gtk/MonoCov.cs, Makefile, configure:
 	Migrate from Mono.GetOptions (obsolete) to Mono.Options
 

--- a/HtmlExporter.cs
+++ b/HtmlExporter.cs
@@ -39,16 +39,6 @@ public class HtmlExporter {
 
 	public event ProgressEventHandler Progress;
 
-	private XmlTextWriter writer;
-
-	private CoverageModel model;
-
-	private static string DefaultStyleSheet = "style.xsl";
-
-	private int itemCount;
-
-	private int itemsProcessed;
-
 	private XslTransform transform;
 
 	//
@@ -57,9 +47,6 @@ public class HtmlExporter {
 	//
  
 	public void Export (CoverageModel model) {
-
-		this.model = model;
-
 		if (model.hit + model.missed == 0)
 			return;
 
@@ -79,9 +66,6 @@ public class HtmlExporter {
 		exporter.StyleSheet = StyleSheet;
 		exporter.DestinationDir = tempDir;
 		exporter.Progress += new XmlExporter.ProgressEventHandler (progressListener);
-		// Count items
-		itemCount = 1 + model.Classes.Count + model.Namespaces.Count;
-		itemsProcessed = 0;
 
 		exporter.Export (model);
 

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,13 @@ SRCS = \
 	SourceFileCoverageData.cs \
 	XmlExporter.cs \
 	HtmlExporter.cs \
+	Options.cs \
+	MonoCovOptions.cs \
 	MonoCovMain.cs \
 	$(GUI_SRCS)
 
 monocov.exe: $(SRCS) style.xsl .gui-$(GUI) $(GUI_DEPS)
-	gmcs -debug /target:exe /out:$@ -define:GUI_$(GUI) $(LIBS) -r:Mono.CompilerServices.SymbolWriter -r:Mono.GetOptions $(GUI_LIBS) $(SRCS) -resource:style.xsl,style.xsl -resource:trans.gif,trans.gif
+	gmcs -debug /target:exe /out:$@ -define:GUI_$(GUI) $(LIBS) -r:Mono.CompilerServices.SymbolWriter $(GUI_LIBS) $(SRCS) -resource:style.xsl,style.xsl -resource:trans.gif,trans.gif
 
 .gui-gtk:
 	@rm -f .gui-*

--- a/MonoCovMain.cs
+++ b/MonoCovMain.cs
@@ -18,7 +18,6 @@ using System;
 using System.Reflection;
 using System.IO;
 using System.Text;
-using Mono.GetOptions;
 #if GUI_qt
 using MonoCov.Gui.Qt;
 #else
@@ -28,32 +27,9 @@ using MonoCov.Gui.Gtk;
 [assembly: AssemblyTitle("monocov")]
 [assembly: AssemblyDescription("A Coverage Analysis program for .NET")]
 [assembly: AssemblyCopyright("Copyright (C) 2003 Zoltan Varga")]
-[assembly: Mono.Author("Zoltan Varga (vargaz@freemail.hu)")]
 [assembly: AssemblyVersion(Constants.Version)]
-[assembly: Mono.UsageComplement("[<datafile>]")]
-[assembly: Mono.About("")]
 
 namespace MonoCov {
-
-public class MonoCovOptions : Options
-{
-	[Option("Export coverage data as XML into directory PARAM", "export-xml")]
-		public string exportXmlDir;
-
-	[Option("Export coverage data as HTML into directory PARAM", "export-html")]
-		public string exportHtmlDir;
-
-	[Option("Use the XSL stylesheet PARAM for XML->HTML conversion", "stylesheet")]
-		public string styleSheet;
-
-	[Option("No progress messages during the export process", "no-progress")]
-		public bool quiet = false;
-
-	public override WhatToDoNext DoAbout() {
-		base.DoAbout ();
-		return WhatToDoNext.AbandonProgram;
-	}
-}
 
 //
 // This class should be named MonoCov, but the GUI class is already
@@ -62,10 +38,15 @@ public class MonoCovOptions : Options
 
 public class MonoCovMain {
 
-	public static int Main (String[] args) {
+	public static int Main (string[] args) {
 		MonoCovOptions options = new MonoCovOptions ();
 		options.ProcessArgs (args);
 		args = options.RemainingArguments;
+
+		if (options.showHelp) {
+			options.WriteHelp(Console.Out);
+			return 0;
+		}
 
 		if (options.exportXmlDir != null)
 			return handleExportXml (options, args);

--- a/MonoCovMain.cs
+++ b/MonoCovMain.cs
@@ -70,7 +70,13 @@ public class MonoCovMain {
 			Console.WriteLine ("Error: Datafile name is required when using --export-xml");
 			return 1;
 		}
-
+		
+		if (!File.Exists(args [0]))
+		{
+			Console.WriteLine(string.Format("Error: Datafile '{0}' not found.", args [0]));
+			return 1;
+		}
+			
 		if (!Directory.Exists (opts.exportXmlDir)) {
 			try {
 				Directory.CreateDirectory (opts.exportXmlDir);
@@ -80,15 +86,22 @@ public class MonoCovMain {
 				return 1;
 			}
 		}
-		
-		CoverageModel model = new CoverageModel ();
-		model.ReadFromFile (args [0]);
-		XmlExporter exporter = new XmlExporter ();
-		exporter.DestinationDir = opts.exportXmlDir;
-		exporter.StyleSheet = opts.styleSheet;
-		if (!opts.quiet)
-			exporter.Progress += new XmlExporter.ProgressEventHandler (progressListener);
-		exporter.Export (model);
+			
+		try {
+			CoverageModel model = new CoverageModel ();
+			model.ReadFromFile (args [0]);
+			XmlExporter exporter = new XmlExporter ();
+			exporter.DestinationDir = opts.exportXmlDir;
+			exporter.StyleSheet = opts.styleSheet;
+			if (!opts.quiet)
+				exporter.Progress += new XmlExporter.ProgressEventHandler (progressListener);
+			exporter.Export (model);
+		}
+		catch (Exception e) {
+			Console.WriteLine("Error: "+e.Message);
+			return 1;
+		}
+			
 		if (!opts.quiet) {
 			Console.WriteLine ();
 			Console.WriteLine ("Done.");
@@ -105,7 +118,12 @@ public class MonoCovMain {
 			Console.WriteLine ("Error: Datafile name is required when using --export-html");
 			return 1;
 		}
-
+		
+		if (!File.Exists(args [0])) {
+			Console.WriteLine(string.Format("Error: Datafile '{0}' not found.", args [0]));
+			return 1;
+		}
+			
 		if (!Directory.Exists (opts.exportHtmlDir)) {
 			try {
 				Directory.CreateDirectory (opts.exportHtmlDir);
@@ -116,14 +134,21 @@ public class MonoCovMain {
 			}
 		}
 		
-		CoverageModel model = new CoverageModel ();
-		model.ReadFromFile (args [0]);
-		HtmlExporter exporter = new HtmlExporter ();
-		exporter.DestinationDir = opts.exportHtmlDir;
-		exporter.StyleSheet = opts.styleSheet;
-		if (!opts.quiet)
-			exporter.Progress += new HtmlExporter.ProgressEventHandler (htmlProgressListener);
-		exporter.Export (model);
+		try {
+			CoverageModel model = new CoverageModel ();
+			model.ReadFromFile (args [0]);
+			HtmlExporter exporter = new HtmlExporter ();
+			exporter.DestinationDir = opts.exportHtmlDir;
+			exporter.StyleSheet = opts.styleSheet;
+			if (!opts.quiet)
+				exporter.Progress += new HtmlExporter.ProgressEventHandler (htmlProgressListener);
+			exporter.Export (model);
+		}
+		catch (Exception e) {
+			Console.WriteLine("Error: "+e.Message);
+			return 1;
+		}
+				
 		if (!opts.quiet) {
 			Console.WriteLine ();
 			Console.WriteLine ("Done.");

--- a/MonoCovOptions.cs
+++ b/MonoCovOptions.cs
@@ -1,0 +1,46 @@
+
+using System.IO;
+using Mono.Options;
+
+namespace MonoCov
+{
+	public class MonoCovOptions
+	{
+		public MonoCovOptions()
+		{
+			optionSet = new OptionSet ();
+			optionSet.Add ("export-xml=", "Export coverage data as XML into specified directory", v => exportXmlDir = v);
+			optionSet.Add ("export-html=", "Export coverage data as HTML into specified directory", v => exportHtmlDir = v);
+			optionSet.Add ("stylesheet=", "Use the specified XSL stylesheet for XML->HTML conversion", v => exportHtmlDir = v);
+			optionSet.Add ("no-progress", "No progress messages during the export process", v => quiet = v != null);
+			optionSet.Add ("h|help", "Show this message and exit", v => showHelp = v != null);			
+		}
+		private OptionSet optionSet;
+		
+		public string exportXmlDir;
+		public string exportHtmlDir;
+		public string styleSheet;
+		public bool quiet = false;
+		public bool showHelp = false;
+
+		public void ProcessArgs (string[] args)
+		{			
+			remainingArguments = optionSet.Parse (args).ToArray ();
+		}
+
+		public string[] RemainingArguments {
+			get { return remainingArguments; }
+		}
+		private string[] remainingArguments = new string[0];
+		
+		public void WriteHelp(TextWriter textWriter)
+		{
+			textWriter.WriteLine("Usage: monocov [OPTIONS]+ [<DATAFILE>]");
+			textWriter.WriteLine();
+			textWriter.WriteLine("Options:");
+			
+			optionSet.WriteOptionDescriptions(textWriter);
+		}
+	}
+}
+

--- a/configure
+++ b/configure
@@ -66,8 +66,8 @@ if test -z "$monooptionssrc"; then
 	exit 1
 else
 	#copy Mono.Options here
-        echo "Using Mono.Options: $monooptionssrc."
-        cp $monooptionssrc .
+	echo "Using Mono.Options: $monooptionssrc."
+	cp $monooptionssrc .
 fi
 
 echo "prefix=$prefix" > config.make

--- a/configure
+++ b/configure
@@ -11,6 +11,7 @@ help()
 
 prefix=/usr/local
 cecilbin=
+monooptionssrc=
 
 while [ $# -ne 0 ]; do
   case $1 in
@@ -54,6 +55,19 @@ else
 	# copy Mono.Cecil here
 	echo "Using Cecil from $cecilbin."
 	cp $cecilbin .
+fi
+
+if test -z "$monooptionssrc"; then
+	monooptionssrc=`pkg-config --variable=Sources mono-options`
+fi
+
+if test -z "$monooptionssrc"; then
+	echo "No Mono.Options found."
+	exit 1
+else
+	#copy Mono.Options here
+        echo "Using Mono.Options: $monooptionssrc."
+        cp $monooptionssrc .
 fi
 
 echo "prefix=$prefix" > config.make

--- a/gui/gtk/CoverageView.cs
+++ b/gui/gtk/CoverageView.cs
@@ -110,7 +110,6 @@ public class CoverageView {
 	
 	TreeView tree;
 	Hashtable namespaces;
-	Hashtable classes;
 	CoverageModel model;
 	Hashtable source_views, window_maps;
 	ProgressBar status;

--- a/gui/gtk/MonoCov.cs
+++ b/gui/gtk/MonoCov.cs
@@ -17,7 +17,6 @@ using System;
 using System.Reflection;
 using System.IO;
 using System.Drawing;
-using Mono.GetOptions;
 
 namespace MonoCov.Gui.Gtk {
 

--- a/gui/qt/MonoCov.cs
+++ b/gui/qt/MonoCov.cs
@@ -11,7 +11,6 @@ using System;
 using System.Reflection;
 using System.IO;
 using System.Text;
-using Mono.GetOptions;
 
 [assembly: AssemblyTitle("monocov")]
 [assembly: AssemblyDescription("A Coverage Analysis program for .NET")]


### PR DESCRIPTION
- Migrate from Mono.GetOptions to Mono.Options (The Mono.GetOptions package has been made obsolete.)
- Never used private fields removed.
- xml/html-export error handling added.
