### PR TITLE
Feature: Use notebook/tabs for source window (Gtk)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2011-01-03  Andreas Windischer
+
+	* gui/gtk/monocov.glade, gui/gtk/SourceWindow.cs, gui/gtk/MonoCov.cs, gui/gtk/CoverageView.cs:
+	Create new source tab in notebook instead of new source window.
+
 2011-01-02  Andreas Windischer
 
 	* gui/gtk/CoverageView.cs: Create the method nodes only when

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2011-01-04  Andreas Windischer
+
+	* gui/gtk/NotebookTabLabel.cs, gui/gtk/monocov.glade, gui/gtk/MonoCov.cs, Makefile:
+	Window menu item and tab close button added.
+
 2011-01-03  Andreas Windischer
 
 	* gui/gtk/monocov.glade, gui/gtk/SourceWindow.cs, gui/gtk/MonoCov.cs, gui/gtk/CoverageView.cs:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GUI_SRCS = \
 	gui/gtk/MonoCov.cs \
 	gui/gtk/CoverageView.cs \
 	gui/gtk/SourceWindow.cs \
-        gui/gtk/NotebookTabLabel.cs
+	gui/gtk/NotebookTabLabel.cs
 GUI_LIBS = -pkg:gtk-sharp-2.0 -pkg:glade-sharp-2.0 -r:System.Drawing -resource:gui/gtk/monocov.glade,monocov.glade
 GUI_DEPS=gui/gtk/monocov.glade
 else

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ ifeq ($(GUI), gtk)
 GUI_SRCS = \
 	gui/gtk/MonoCov.cs \
 	gui/gtk/CoverageView.cs \
-	gui/gtk/SourceWindow.cs
+	gui/gtk/SourceWindow.cs \
+        gui/gtk/NotebookTabLabel.cs
 GUI_LIBS = -pkg:gtk-sharp-2.0 -pkg:glade-sharp-2.0 -r:System.Drawing -resource:gui/gtk/monocov.glade,monocov.glade
 GUI_DEPS=gui/gtk/monocov.glade
 else

--- a/gui/gtk/MonoCov.cs
+++ b/gui/gtk/MonoCov.cs
@@ -96,8 +96,7 @@ public class MonoCovGui {
 			scrolledwindow1.Remove (coverageView.Widget);
 			coverageView.ShowSource -= OnShowSource;
 
-			while (notebook1.NPages != 0)
-				notebook1.RemovePage (0);
+			OnCloseAllTabs (this, EventArgs.Empty);
 		}
 
 		progressbar1.Show ();
@@ -154,8 +153,13 @@ public class MonoCovGui {
 		string sourceFile = e.methodItem.ParentClass.Model.sourceFile.sourceFile;
 		sourceFile = Path.GetFileName (sourceFile);
 
-		int index = notebook1.AppendPage (sourceWindow, new Label (sourceFile));
+		NotebookTabLabel notebookTabLabel = new NotebookTabLabel (sourceFile);
+		int index = notebook1.AppendPage (sourceWindow, notebookTabLabel);
 		notebook1.CurrentPage = index;
+		notebookTabLabel.CloseClicked += delegate(object obj, EventArgs eventArgs) {
+			notebook1.CurrentPage = notebook1.PageNum (sourceWindow);
+			OnCloseTab (this, EventArgs.Empty);
+		};
 	}
 
 	private void ExportAsXml (string destDir)
@@ -202,6 +206,31 @@ public class MonoCovGui {
 			return;
 
 		notebook1.RemovePage (notebook1.CurrentPage);
+	}
+
+	public void OnCloseAllTabs (object o, EventArgs args)
+	{
+		if (notebook1 == null)
+			return;
+		
+		while (notebook1.NPages != 0)
+			OnCloseTab (this, EventArgs.Empty);
+	}
+
+	public void OnNextTab (object o, EventArgs args)
+	{
+		if (notebook1 == null || notebook1.NPages == 0)
+			return;
+		
+		notebook1.NextPage ();
+	}
+
+	public void OnPreviousTab (object o, EventArgs args)
+	{
+		if (notebook1 == null || notebook1.NPages == 0)
+			return;
+		
+		notebook1.PrevPage ();
 	}
 }
 }

--- a/gui/gtk/NotebookTabLabel.cs
+++ b/gui/gtk/NotebookTabLabel.cs
@@ -1,0 +1,54 @@
+
+using System;
+using Gtk;
+using Gdk;
+
+namespace MonoCov
+{
+	public class NotebookTabLabel : EventBox
+	{
+		public NotebookTabLabel (string title)
+		{
+			Button button = new Button ();
+			button.Image = new Gtk.Image (Stock.Close, IconSize.Menu);
+			button.TooltipText = "Close Tab";
+			button.Relief = ReliefStyle.None;
+			
+			RcStyle rcStyle = new RcStyle ();
+			rcStyle.Xthickness = 0;
+			rcStyle.Ythickness = 0;
+			button.ModifyStyle (rcStyle);
+			
+			button.FocusOnClick = false;
+			button.Clicked += OnCloseClicked;
+			button.Show ();
+			
+			Label label = new Label (title);
+			label.UseMarkup = false;
+			label.UseUnderline = false;
+			label.Show ();
+			
+			HBox hbox = new HBox (false, 0);
+			hbox.Spacing = 0;
+			hbox.Add (label);
+			hbox.Add (button);
+			hbox.Show ();
+			
+			this.Add (hbox);
+		}
+
+		public event EventHandler<EventArgs> CloseClicked;
+
+		public void OnCloseClicked (object sender, EventArgs e)
+		{
+			if (CloseClicked != null)
+				CloseClicked (sender, e);
+		}
+
+		public void OnCloseClicked ()
+		{
+			OnCloseClicked (this, EventArgs.Empty);
+		}
+	}
+}
+

--- a/gui/gtk/SourceWindow.cs
+++ b/gui/gtk/SourceWindow.cs
@@ -4,25 +4,21 @@ using System.IO;
 
 namespace MonoCov.Gui.Gtk{
 
-	public class SourceWindow : Window {
+	public class SourceWindow : ScrolledWindow {
 		TextView text_view;
 		TextBuffer text_buffer;
 		TextTag hit_color;
 		TextTag missed_color;
+		public CoverageView.ClassItem classItem;
 		
 		public SourceWindow (CoverageView.ClassItem klass)
-			: base (klass.Model.sourceFile.sourceFile)
 		{
-			SetDefaultSize (800, 600);
-
-			ScrolledWindow sw = new ScrolledWindow ();
-			
+			this.classItem=klass;
 			text_buffer = new TextBuffer (new TextTagTable ());
 			text_view = new TextView (text_buffer);
 			text_view.Editable = false;
 
-			sw.Add (text_view);
-			Add (sw);
+			Add (text_view);
 
 			hit_color = new TextTag ("hit");
 			hit_color.Foreground = "blue";

--- a/gui/gtk/monocov.glade
+++ b/gui/gtk/monocov.glade
@@ -60,16 +60,54 @@
 		  </child>
 
 		  <child>
-		    <widget class="GtkImageMenuItem" id="closetab1">
+		    <widget class="GtkImageMenuItem" id="quit1">
 		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">_Close Tab</property>
+		      <property name="label">gtk-quit</property>
+		      <property name="use_stock">True</property>
+		      <signal name="activate" handler="OnQuit" last_modification_time="Thu, 29 May 2003 13:54:37 GMT"/>
+		    </widget>
+		  </child>
+		</widget>
+	      </child>
+	    </widget>
+	  </child>
+
+	  <child>
+	    <widget class="GtkMenuItem" id="menuitem8">
+	      <property name="visible">True</property>
+	      <property name="label" translatable="yes">_Window</property>
+	      <property name="use_underline">True</property>
+	      <child>
+		<widget class="GtkMenu" id="menuitem8_menu">
+
+		  <child>
+		    <widget class="GtkImageMenuItem" id="nexttab1">
+		      <property name="visible">True</property>
+		      <property name="label" translatable="yes">_Next Tab</property>
 		      <property name="use_underline">True</property>
-		      <signal name="activate" handler="OnCloseTab" />
-		      <accelerator key="w" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+		      <signal name="activate" handler="OnNextTab" />
+		      <accelerator key="Page_Down" signal="activate" modifiers="GDK_CONTROL_MASK" />
 		      <child internal-child="image">
 			<widget class="GtkImage" id="image1">
 			  <property name="visible">True</property>
-			  <property name="stock">gtk-close</property>
+			  <property name="stock">gtk-go-forward</property>
+			  <property name="icon-size">1</property>
+			</widget>
+		      </child>
+		    </widget>
+		  </child>
+
+		  <child>
+		    <widget class="GtkImageMenuItem" id="previoustab1">
+		      <property name="visible">True</property>
+		      <property name="label" translatable="yes">_Previous Tab</property>
+		      <property name="use_underline">True</property>
+		      <signal name="activate" handler="OnPreviousTab" />
+		      <accelerator key="Page_Up" signal="activate" modifiers="GDK_CONTROL_MASK" />
+		      <child internal-child="image">
+			<widget class="GtkImage" id="image1">
+			  <property name="visible">True</property>
+			  <property name="stock">gtk-go-back</property>
 			  <property name="icon-size">1</property>
 			</widget>
 		      </child>
@@ -83,11 +121,29 @@
 		  </child>
 
 		  <child>
-		    <widget class="GtkImageMenuItem" id="quit1">
+		    <widget class="GtkImageMenuItem" id="closetab1">
 		      <property name="visible">True</property>
-		      <property name="label">gtk-quit</property>
-		      <property name="use_stock">True</property>
-		      <signal name="activate" handler="OnQuit" last_modification_time="Thu, 29 May 2003 13:54:37 GMT"/>
+		      <property name="label" translatable="yes">_Close Current Tab</property>
+		      <property name="use_underline">True</property>
+		      <signal name="activate" handler="OnCloseTab" />
+		      <accelerator key="w" signal="activate" modifiers="GDK_CONTROL_MASK" />
+		      <child internal-child="image">
+			<widget class="GtkImage" id="image1">
+			  <property name="visible">True</property>
+			  <property name="stock">gtk-close</property>
+			  <property name="icon-size">1</property>
+			</widget>
+		      </child>
+		    </widget>
+		  </child>
+
+		  <child>
+		    <widget class="GtkImageMenuItem" id="closealltabs1">
+		      <property name="visible">True</property>
+		      <property name="label" translatable="yes">_Close All Tabs</property>
+		      <property name="use_underline">True</property>
+		      <signal name="activate" handler="OnCloseAllTabs" />
+		      <accelerator key="w" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK" />
 		    </widget>
 		  </child>
 		</widget>
@@ -140,11 +196,6 @@
 		<placeholder/>
 	      </child>
 	    </widget>
-	    <packing>
-	      <property name="padding">2</property>
-	      <property name="expand">True</property>
-	      <property name="fill">True</property>
-	    </packing>
           </child>
 
 	  <child>

--- a/gui/gtk/monocov.glade
+++ b/gui/gtk/monocov.glade
@@ -27,6 +27,7 @@
       <property name="visible">True</property>
       <property name="homogeneous">False</property>
       <property name="spacing">0</property>
+      <property name="orientation">vertical</property>
 
       <child>
 	<widget class="GtkMenuBar" id="menubar1">
@@ -49,6 +50,29 @@
 		      <property name="label">gtk-open</property>
 		      <property name="use_stock">True</property>
 		      <signal name="activate" handler="OnOpen" last_modification_time="Thu, 29 May 2003 13:54:37 GMT"/>
+		    </widget>
+		  </child>
+
+		  <child>
+		    <widget class="GtkMenuItem" id="separatormenuitem1">
+		      <property name="visible">True</property>
+		    </widget>
+		  </child>
+
+		  <child>
+		    <widget class="GtkImageMenuItem" id="closetab1">
+		      <property name="visible">True</property>
+		      <property name="label" translatable="yes">_Close Tab</property>
+		      <property name="use_underline">True</property>
+		      <signal name="activate" handler="OnCloseTab" />
+		      <accelerator key="w" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+		      <child internal-child="image">
+			<widget class="GtkImage" id="image1">
+			  <property name="visible">True</property>
+			  <property name="stock">gtk-close</property>
+			  <property name="icon-size">1</property>
+			</widget>
+		      </child>
 		    </widget>
 		  </child>
 
@@ -101,27 +125,35 @@
       </child>
 
       <child>
-	<placeholder/>
-      </child>
-
-      <child>
-	<widget class="GtkScrolledWindow" id="scrolledwindow1">
+	<widget class="GtkVPaned" id="vpaned1">
 	  <property name="visible">True</property>
-	  <property name="can_focus">True</property>
-	  <property name="hscrollbar_policy">GTK_POLICY_NEVER</property>
-	  <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-	  <property name="shadow_type">GTK_SHADOW_NONE</property>
-	  <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
 
 	  <child>
-	    <placeholder/>
+	    <widget class="GtkScrolledWindow" id="scrolledwindow1">
+	      <property name="visible">True</property>
+	      <property name="can_focus">True</property>
+	      <property name="hscrollbar_policy">GTK_POLICY_NEVER</property>
+	      <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+	      <property name="shadow_type">GTK_SHADOW_NONE</property>
+	      <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+	      <child>
+		<placeholder/>
+	      </child>
+	    </widget>
+	    <packing>
+	      <property name="padding">2</property>
+	      <property name="expand">True</property>
+	      <property name="fill">True</property>
+	    </packing>
+          </child>
+
+	  <child>
+	    <widget class="GtkNotebook" id="notebook1">
+	      <property name="visible">True</property>
+	    </widget>
 	  </child>
+
 	</widget>
-	<packing>
-	  <property name="padding">2</property>
-	  <property name="expand">True</property>
-	  <property name="fill">True</property>
-	</packing>
       </child>
 
       <child>


### PR DESCRIPTION
Hello,

to improve usability, I use a Paned widget with two children arranged vertically: The upper child is a tree view. The lower child is a Notebook widget where opened source files will be displayed. Each tab has a close button.

What do you think?

Best wishes, Andreas.

Screenshot: http://www.alpinechough.com/monocov/userinterface/monocov.png
