### PR TITLE
Feature: Test Code Coverage

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2011-01-12  Andreas Windischer
+
+	* MonoCovMain.cs, MonoCovOptions.cs, monocov.1, README:
+	The application will return an exit code which can be used to determine if all
+	classes/methodes have a greater code coverage than specified.
+
 2011-01-02  Andreas Windischer
 
 	* gui/gtk/CoverageView.cs: Create the method nodes only when

--- a/MonoCovOptions.cs
+++ b/MonoCovOptions.cs
@@ -12,6 +12,8 @@ namespace MonoCov
 			optionSet.Add ("export-xml=", "Export coverage data as XML into specified directory", v => exportXmlDir = v);
 			optionSet.Add ("export-html=", "Export coverage data as HTML into specified directory", v => exportHtmlDir = v);
 			optionSet.Add ("stylesheet=", "Use the specified XSL stylesheet for XML->HTML conversion", v => exportHtmlDir = v);
+			optionSet.Add ("minClassCoverage=", "If a code coverage of a class is less than specified, the application exits with return code 1.", v => float.TryParse(v, out minClassCoverage));
+			optionSet.Add ("minMethodeCoverage=", "If a code coverage of a methode is less than specified, the application exits with return code 1.", v => float.TryParse(v, out minMethodeCoverage));
 			optionSet.Add ("no-progress", "No progress messages during the export process", v => quiet = v != null);
 			optionSet.Add ("h|help", "Show this message and exit", v => showHelp = v != null);			
 		}
@@ -20,6 +22,8 @@ namespace MonoCov
 		public string exportXmlDir;
 		public string exportHtmlDir;
 		public string styleSheet;
+		public float minClassCoverage = -1f;
+		public float minMethodeCoverage = -1f;
 		public bool quiet = false;
 		public bool showHelp = false;
 

--- a/README
+++ b/README
@@ -77,7 +77,7 @@ To export the data as HTML, run monocov like this:
 You can use this application to track your code coverage as part of your build
 process. To specify a minimum methode coverage of 50% and a minimum class coverage
 of 80%:
-	monocov --minClassCoverage=0.5 minMethodeCoverage=0.8 <DATA FILE NAME>
+	monocov --minMethodeCoverage=0.5 --minClassCoverage=0.8 <DATA FILE NAME>
 
 The application will return an exit code which can be used to determine if all
 classes/methodes have a greater code coverage than specified.

--- a/README
+++ b/README
@@ -74,6 +74,14 @@ be good if somebody could contribute a better one :)
 To export the data as HTML, run monocov like this:
 	monocov --export-html=<DEST DIR> <DATA FILE NAME>
 
+You can use this application to track your code coverage as part of your build
+process. To specify a minimum methode coverage of 50% and a minimum class coverage
+of 80%:
+	monocov --minClassCoverage=0.5 minMethodeCoverage=0.8 <DATA FILE NAME>
+
+The application will return an exit code which can be used to determine if all
+classes/methodes have a greater code coverage than specified.
+
 2.5 KNOWN BUGS
 --------------
 

--- a/monocov.1
+++ b/monocov.1
@@ -12,6 +12,12 @@ Export the coverage data as HTML files in directory DIR.
 .I \-export-xml:DIR
 Export the coverage data as XML files in directory DIR.
 .TP
+.I \-test-class:VALUE
+If a code coverage of a class is less than specified, the application exits with return code 1.
+.TP
+.I \-test-methode:VALUE
+If a code coverage of a methode is less than specified, the application exits with return code 1.
+.TP
 .I \-version
 Print version information.
 .TP


### PR DESCRIPTION
You can use this application to track your code coverage as part of your build process. To specify a minimum methode coverage of 50% and a minimum class coverage of 80%:
    monocov --minMethodeCoverage=0.5 --minClassCoverage=0.8 <DATA FILE NAME>

The application will return an exit code which can be used to determine if all classes/methodes have a greater code coverage than specified.
