### PR TITLE
Feature: If assembly could not be found, search in datafile-directory.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2011-01-15  Andreas Windischer
 
 	* gui/gtk/CoverageView.cs: Expand on double click fix.
+	* CoverageModel.cs: If assembly could not be found, search in datafile-directory.
 
 2011-01-12  Andreas Windischer
 

--- a/CoverageModel.cs
+++ b/CoverageModel.cs
@@ -16,6 +16,7 @@ public delegate void CoverageProgress (string item, double percent);
 
 public class CoverageModel : CoverageItem {
 
+	private string dataFileName;
 	private Hashtable namespaces;
 	private Hashtable classes;
 	private Hashtable sources;
@@ -32,6 +33,7 @@ public class CoverageModel : CoverageItem {
 
 	public CoverageModel ()
 	{
+		dataFileName = string.Empty;
 		namespaces = new Hashtable ();
 		classes = new Hashtable ();
 		sources = new Hashtable ();
@@ -93,6 +95,12 @@ public class CoverageModel : CoverageItem {
 			string guid = n.Attributes ["guid"].Value;
 			string filename = n.Attributes ["filename"].Value;
 			MonoSymbolFile symbolFile;
+
+			if (!File.Exists (filename)) {
+				string newFilename = Path.Combine(Path.GetDirectoryName (dataFileName), Path.GetFileName (filename));
+				if (File.Exists (newFilename))
+					filename = newFilename;
+			}
 
 #if USE_REFLECTION
 			Assembly assembly = Assembly.Load (assemblyName);
@@ -190,6 +198,7 @@ public class CoverageModel : CoverageItem {
 
 	public void ReadFromFile (string fileName)
 	{
+		dataFileName = fileName;
 		namespaces = new Hashtable ();
 		classes = new Hashtable ();
 


### PR DESCRIPTION
Hello,

if I run a nunit-test the assembly under test will be copied to "/tmp/nunit20/ShadowCopyCache/[...]". After the test, nunit removes the cache and monocov.exe will fail, because it could not find the assembly.

I think most of the times the coverage output file will be in the same directory as the assemblies are - so lets have a try and look there.

Kind regards,
Andreas
