### PR TITLE
Bugfix: Check fgets return value

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2011-01-16  Andreas Windischer
+
+	* coverage.c: Check fgets return value.
+
 2011-01-15  Andreas Windischer
 
 	* gui/gtk/CoverageView.cs: Expand on double click fix.

--- a/coverage.c
+++ b/coverage.c
@@ -100,10 +100,8 @@ mono_profiler_startup (char *arg)
 			exit (1);
 		}
 
-		while (!feof (filterfile)) {
-			char buf [2048];
-
-			fgets (buf, 2048, filterfile);
+		char buf [2048];
+		while (fgets (buf, 2048, filterfile) != NULL) {
 			buf [sizeof (buf) - 1] = '\0';
 
 			if ((buf [0] == '#') || (buf [0] == '\0'))


### PR DESCRIPTION
Hello,

compiling "coverage.c" will show: "warning: ignoring return value of 'fgets', declared with attribute warn_unused_result" This patch checks the return value.

Kind regards,
Andreas
