### PR TITLE
I tried to fix build on mono 2.10.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ nunit-console.exe: nunit-console.cs
 	gmcs -r:nunit.framework -r:nunit.core -r:nunit.util -r:Mono.GetOptions nunit-console.cs
 
 libmono-profiler-monocov.so: coverage.c
-	$(CC) $(CFLAGS) -DVERSION=\"$(VERSION)\" `pkg-config --cflags mono` --shared -fPIC -o $@ $^
+	$(CC) $(CFLAGS) -DVERSION=\"$(VERSION)\" `pkg-config --cflags mono-2` `pkg-config --libs mono-2` `pkg-config --cflags glib-2.0` `pkg-config --libs glib-2.0` --shared -fPIC -o $@ $^
 
 install: all
 	mkdir -p $(prefix)/lib/monocov

--- a/coverage.c
+++ b/coverage.c
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <glib.h>
 
 #include <mono/metadata/class.h>
 #include <mono/metadata/assembly.h>


### PR DESCRIPTION
I was unable to build monocov with mono 2.10.2 due to missing glib.
I modified converage.c to include glib and and Makefile to adopt the flags and libs from glib-2.0.pc and mono-2.pc.

Now it builds and works on my Debian parallel environment.

Hope this help.
